### PR TITLE
Add Routing and Faulting packages

### DIFF
--- a/control
+++ b/control
@@ -8,10 +8,9 @@ Description: Adds custom devices to NI VeriStand.
 XB-Eula: eula-ni-standard,
 Priority: standard
 Homepage: http://www.ni.com
-Recommends: ni-scan-engine-veristand-{veristand_version}-support (>={display_version}), ni-synchronization-veristand-{veristand_version}-support (>={display_version}), ni-engine-simulation-veristand-{veristand_version}-support (>={display_version}), ni-slsc12201-veristand-{veristand_version}-support (>={display_version}), ni-slsc-eds-veristand-{veristand_version}-support (>={display_version}),
-Suggests: ni-system-monitor-veristand-{veristand_version}-support (>={display_version}),
+Recommends: ni-scan-engine-veristand-{veristand_version}-support (>=19.1.0), ni-synchronization-veristand-{veristand_version}-support (>=19.1.0), ni-engine-simulation-veristand-{veristand_version}-support (>=19.1.0), ni-slsc12201-veristand-{veristand_version}-support (>=19.1.0), ni-slsc-eds-veristand-{veristand_version}-support (>=19.1.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>=19.2.0), ni-slsc-switch-veristand-{veristand_version}-support (>=19.2.0),
 XB-LanguageSupport: en
-XB-AlwaysRemoves: ni-scan-engine-veristand-2019-support, ni-synchronization-veristand-2019-support, ni-engine-simulation-veristand-2019-support, ni-slsc12201-veristand-2019-support, ni-slsc-eds-veristand-2019-support, ni-system-monitor-veristand-2019-support,
+XB-AlwaysRemoves: ni-scan-engine-veristand-2019-support, ni-synchronization-veristand-2019-support, ni-engine-simulation-veristand-2019-support, ni-slsc12201-veristand-2019-support, ni-slsc-eds-veristand-2019-support, ni-routing-and-faulting-veristand-2019-support, ni-slsc-switch-veristand-2019-support,
 XB-StoreProduct: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-virtual-package/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds recommendations for Routing and Faulting and SLSC Switch packages,
Includes explicit versions so packages that aren't branched are still recommended.
Removes system monitor since this is not a shipping package.

### Why should this Pull Request be merged?

We need these packages as part of our feed.

### What testing has been done?

None. Need release build to test packages.

**Note**: [niveristand-routing-and-faulting-custom-device PR-51](https://github.com/ni/niveristand-routing-and-faulting-custom-device/pull/51) must be built into the 19.2 release branch before this virtual package will successfully install them.
