### PR TITLE
Recommend the Embedded Data Logger

### DIFF
--- a/control
+++ b/control
@@ -8,9 +8,9 @@ Description: Adds custom devices to NI VeriStand.
 XB-Eula: eula-ni-standard,
 Priority: standard
 Homepage: http://www.ni.com
-Recommends: ni-scan-engine-veristand-{veristand_version}-support (>=19.1.0), ni-synchronization-veristand-{veristand_version}-support (>=19.1.0), ni-engine-simulation-veristand-{veristand_version}-support (>=19.1.0), ni-slsc12201-veristand-{veristand_version}-support (>=19.1.0), ni-slsc-eds-veristand-{veristand_version}-support (>=19.1.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>=19.2.0), ni-slsc-switch-veristand-{veristand_version}-support (>=19.2.0),
+Recommends: ni-scan-engine-veristand-{veristand_version}-support (>=19.1.0), ni-synchronization-veristand-{veristand_version}-support (>=19.1.0), ni-engine-simulation-veristand-{veristand_version}-support (>=19.1.0), ni-slsc12201-veristand-{veristand_version}-support (>=19.1.0), ni-slsc-eds-veristand-{veristand_version}-support (>=19.1.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>=19.2.0), ni-slsc-switch-veristand-{veristand_version}-support (>=19.2.0), ni-embedded-data-logger-veristand-{veristand_version}-support (>= 20.0.0),
 XB-LanguageSupport: en
-XB-AlwaysRemoves: ni-scan-engine-veristand-2019-support, ni-synchronization-veristand-2019-support, ni-engine-simulation-veristand-2019-support, ni-slsc12201-veristand-2019-support, ni-slsc-eds-veristand-2019-support, ni-routing-and-faulting-veristand-2019-support, ni-slsc-switch-veristand-2019-support,
+XB-AlwaysRemoves: ni-scan-engine-veristand-2019-support, ni-synchronization-veristand-2019-support, ni-engine-simulation-veristand-2019-support, ni-slsc12201-veristand-2019-support, ni-slsc-eds-veristand-2019-support, ni-routing-and-faulting-veristand-2019-support, ni-slsc-switch-veristand-2019-support, ni-embedded-data-logger-veristand-2019-support,
 XB-StoreProduct: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-virtual-package/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add `ni-embedded-data-logger-veristand-{veristand_version}-support` as a recommended package.

I also added it to the `XB-AlwaysRemoves` property to be consistent, although it seems weird that this property hard codes the 2019 versions. We also need to change the package name to be version specific, so that we can have one version of custom devices installed for 2019 and a different version of them installed for 2020 simultaneously. @buckd

### Why should this Pull Request be merged?

The virtual package currently does not recommend the embedded data logger, which is breaking the some tests. 

### What testing has been done?

None, we will test by building a feed and running the ATS.