### PR TITLE
Include the VeriStand version in the virtual package name

### DIFF
--- a/control
+++ b/control
@@ -9,6 +9,8 @@ XB-Eula: eula-ni-standard,
 Priority: standard
 Homepage: http://www.ni.com
 Recommends: ni-scan-engine-veristand-{veristand_version}-support (>=19.1.0), ni-synchronization-veristand-{veristand_version}-support (>=19.1.0), ni-engine-simulation-veristand-{veristand_version}-support (>=19.1.0), ni-slsc12201-veristand-{veristand_version}-support (>=19.1.0), ni-slsc-eds-veristand-{veristand_version}-support (>=19.1.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>=19.2.0), ni-slsc-switch-veristand-{veristand_version}-support (>=19.2.0),
+Conflicts: ni-veristand-custom-device-support
+Replaces: ni-veristand-custom-device-support
 XB-LanguageSupport: en
 XB-AlwaysRemoves: ni-scan-engine-veristand-2019-support, ni-synchronization-veristand-2019-support, ni-engine-simulation-veristand-2019-support, ni-slsc12201-veristand-2019-support, ni-slsc-eds-veristand-2019-support, ni-routing-and-faulting-veristand-2019-support, ni-slsc-switch-veristand-2019-support,
 XB-StoreProduct: yes

--- a/control
+++ b/control
@@ -12,7 +12,7 @@ Recommends: ni-scan-engine-veristand-{veristand_version}-support (>=19.1.0), ni-
 Conflicts: ni-veristand-custom-device-support
 Replaces: ni-veristand-custom-device-support
 XB-LanguageSupport: en
-XB-AlwaysRemoves: ni-scan-engine-veristand-2019-support, ni-synchronization-veristand-2019-support, ni-engine-simulation-veristand-2019-support, ni-slsc12201-veristand-2019-support, ni-slsc-eds-veristand-2019-support, ni-routing-and-faulting-veristand-2019-support, ni-slsc-switch-veristand-2019-support, ni-embedded-data-logger-veristand-2019-support,
+XB-AlwaysRemoves: ni-scan-engine-veristand-{veristand_version}-support, ni-synchronization-veristand-{veristand_version}-support, ni-engine-simulation-veristand-{veristand_version}-support, ni-slsc12201-veristand-{veristand_version}-support, ni-slsc-eds-veristand-{veristand_version}-support, ni-routing-and-faulting-veristand-{veristand_version}-support, ni-slsc-switch-veristand-{veristand_version}-support, ni-embedded-data-logger-veristand-{veristand_version}-support,
 XB-StoreProduct: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}

--- a/control
+++ b/control
@@ -1,9 +1,9 @@
-Package: ni-veristand-custom-device-support
+Package: ni-veristand-{veristand_version}-custom-device-support
 Version: {nipkg_version}
 Architecture: windows_all
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
-Description: Adds custom devices to NI VeriStand.
+Description: Adds custom devices to NI VeriStand {veristand_version}.
   Custom devices are add-ons that provide extended functionality to the NI VeriStand environment.
 XB-Eula: eula-ni-standard,
 Priority: standard
@@ -14,5 +14,5 @@ XB-AlwaysRemoves: ni-scan-engine-veristand-2019-support, ni-synchronization-veri
 XB-StoreProduct: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
-XB-DisplayName: NI VeriStand Custom Devices
+XB-DisplayName: NI VeriStand {veristand_version} Custom Devices
 XB-UserVisible: yes


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-virtual-package/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add the VeriStand version to the virtual package package name.

### Why should this Pull Request be merged?

We want to allow installing the custom devices for multiple year versions of VeriStand.

*Currently all year versions conflict with and replace the unversioned (2019) virtual package. We will need to do additional work to make only the 2019 versioned virtual package do this, but I am leaving that out of this pull request.*

### What testing has been done?

None.