### PR TITLE
Revert "Include the VeriStand version in the virtual package name"

### DIFF
--- a/control
+++ b/control
@@ -1,20 +1,18 @@
-Package: ni-veristand-{veristand_version}-custom-device-support
+Package: ni-veristand-custom-device-support
 Version: {nipkg_version}
 Architecture: windows_all
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
-Description: Adds custom devices to NI VeriStand {veristand_version}.
+Description: Adds custom devices to NI VeriStand.
   Custom devices are add-ons that provide extended functionality to the NI VeriStand environment.
 XB-Eula: eula-ni-standard,
 Priority: standard
 Homepage: http://www.ni.com
 Recommends: ni-scan-engine-veristand-{veristand_version}-support (>=19.1.0), ni-synchronization-veristand-{veristand_version}-support (>=19.1.0), ni-engine-simulation-veristand-{veristand_version}-support (>=19.1.0), ni-slsc12201-veristand-{veristand_version}-support (>=19.1.0), ni-slsc-eds-veristand-{veristand_version}-support (>=19.1.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>=19.2.0), ni-slsc-switch-veristand-{veristand_version}-support (>=19.2.0), ni-embedded-data-logger-veristand-{veristand_version}-support (>= 20.0.0),
-Conflicts: ni-veristand-custom-device-support
-Replaces: ni-veristand-custom-device-support
 XB-LanguageSupport: en
-XB-AlwaysRemoves: ni-scan-engine-veristand-{veristand_version}-support, ni-synchronization-veristand-{veristand_version}-support, ni-engine-simulation-veristand-{veristand_version}-support, ni-slsc12201-veristand-{veristand_version}-support, ni-slsc-eds-veristand-{veristand_version}-support, ni-routing-and-faulting-veristand-{veristand_version}-support, ni-slsc-switch-veristand-{veristand_version}-support, ni-embedded-data-logger-veristand-{veristand_version}-support,
+XB-AlwaysRemoves: ni-scan-engine-veristand-2019-support, ni-synchronization-veristand-2019-support, ni-engine-simulation-veristand-2019-support, ni-slsc12201-veristand-2019-support, ni-slsc-eds-veristand-2019-support, ni-routing-and-faulting-veristand-2019-support, ni-slsc-switch-veristand-2019-support, ni-embedded-data-logger-veristand-2019-support,
 XB-StoreProduct: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
-XB-DisplayName: NI VeriStand {veristand_version} Custom Devices
+XB-DisplayName: NI VeriStand Custom Devices
 XB-UserVisible: yes


### PR DESCRIPTION
After further discussion, it is not clear that we want to have multiple top-level virtual packages. Reverting for now until a decision is made.