### PR TITLE
Enable notifications and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add names of code owners for this repo
-* @niphilj @buckd
+* @buckd @rtzoeller

--- a/build.toml
+++ b/build.toml
@@ -6,3 +6,6 @@ archive_location = '\\nirvana\Measurements\VeriStandAddons\download_item_package
 type = 'nipkg'
 payload_dir = 'Built'
 install_destination = '' # Create virtual package with no payload
+
+[notification]
+type = 'teams'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables build notifications to MS Teams
Updates codeowners

### Why should this Pull Request be merged?

Build failures will send notifications and codeowners have changed.

### What testing has been done?

None
